### PR TITLE
修复项目启动时无法访问 athena 中的接口问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:22.04
 
 LABEL maintainer="A-Little-Excited"
-LABEL maintainer-email="3030036858@qq.com"
+LABEL maintainer-email="siyangchen@paion-data.dev"
 
 ARG WS_VERSION=1.0-SNAPSHOT
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,17 @@ services:
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=root
       - SPRING_DATASOURCE_URL=jdbc:mysql://db/athena?serverTimezone=UTC
-      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver
+      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
       - SPRING_JDBC_DATABASE_PLATFORM=org.hibernate.dialect.MySQLDialect
-      - HIBERNATE_HBM2DDL_AUTO=create
-      - ATHENA_SPRING_ALIOSS_ENABLED=true
+      - ATHENA_SPRING_ALIOSS_ENABLED=false
       - ATHENA_TEST_ENABLED=true
+      - athena__alioss_endpoint_key=test_key
+      - athena__table_name=TEST_META_DATA
     depends_on:
       db:
         condition: service_healthy
   db:
-    image: "mysql:5.7.43"
+    image: "mysql:8.0.26"
     ports:
       - "3306:3306"
     volumes:

--- a/mysql-init.sql
+++ b/mysql-init.sql
@@ -1,2 +1,28 @@
+-- Copyright 2024 Paion Data
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 CREATE DATABASE IF NOT EXISTS athena;
 USE athena;
+
+CREATE TABLE TEST_META_DATA (
+    id        int NOT NULL AUTO_INCREMENT,
+    file_id   VARCHAR(255) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    file_type VARCHAR(8)   NOT NULL,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO TEST_META_DATA (file_id, file_name, file_type) VALUES ('1', 'Harry Potter', 'PDF');
+INSERT INTO TEST_META_DATA (file_id, file_name, file_type) VALUES ('2', 'Moby Dick', 'PDF');
+INSERT INTO TEST_META_DATA (file_id, file_name, file_type) VALUES ('3', 'Interview with the vampire', 'PDF');

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>groovy-json</artifactId>
             <version>4.0.6</version>
         </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.26</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/paiondata/minerva/App.java
+++ b/src/main/java/com/paiondata/minerva/App.java
@@ -17,6 +17,7 @@ package com.paiondata.minerva;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 /**
  * Spring Boot application startup class
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * the entire Spring Boot application.
  */
 @SpringBootApplication
+@ComponentScan(value = {"com.paiondata.athena.spring.boot.autoconfigure", "com.paiondata.minerva.config"})
 public class App {
     /**
      * Start the SpringBoot application.

--- a/src/main/java/com/paiondata/minerva/config/TestClientConfig.java
+++ b/src/main/java/com/paiondata/minerva/config/TestClientConfig.java
@@ -17,11 +17,16 @@ package com.paiondata.minerva.config;
 
 import com.aliyun.oss.OSS;
 import com.paiondata.aliOSS.TestOSSClient;
+import com.paiondata.athena.file.identifier.FileIdGenerator;
+import com.paiondata.athena.filestore.FileStore;
+import com.paiondata.athena.filestore.alioss.AliOSSFileStore;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Configuration for TestClient.
@@ -41,5 +46,18 @@ public class TestClientConfig {
     @ConditionalOnProperty(name = "athena.test.enabled", havingValue = "true")
     public OSS testOSSClient() {
         return new TestOSSClient();
+    }
+
+    /**
+     * Uses an in-memory file store.
+     *
+     * @param ossClient  The injected file storage client
+     * @param fileIdGenerator  The file ID generator
+     *
+     * @return a new instance
+     */
+    @Bean
+    FileStore fileStore(@NotNull final OSS ossClient, @NotNull final FileIdGenerator fileIdGenerator) {
+        return new AliOSSFileStore(ossClient, fileIdGenerator);
     }
 }


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed
之前的 minerva 启动时由于缺少配置的问题，而无法正常访问 athena 模块中的接口，现在进行修复

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
